### PR TITLE
🚑️ hotfix: Corrigiendo bug critico en el método parse_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kanizawa Sensei Telegram Bot
 
-This is a Telegram bot that can teach you the Rust programming language mediant easy examples of code and short descriptions, moderate your groups and more
+This is a Telegram bot that can teach you the Rust programming language by easy examples of code and short descriptions, moderate your groups and more
 
 
 ## Features
@@ -38,7 +38,7 @@ cargo run
 
 Contributions are always welcome!
 
-See `contributing.md` for ways to get started.
+See [Contributing Book](https://crawkatt.github.io/kanizawa_sensei_book/) for ways to get started.
 
 Please adhere to this project's `code of conduct`.
 

--- a/src/commands/admin/ban.rs
+++ b/src/commands/admin/ban.rs
@@ -1,12 +1,7 @@
-use teloxide_core::{
-    payloads::SendMessageSetters,
-    prelude::{
-        Requester,
-        UserId
-    },
-    requests::ResponseResult,
-    types::Message
-};
+use teloxide_core::payloads::SendMessageSetters;
+use teloxide_core::requests::ResponseResult;
+use teloxide_core::types::Message;
+use teloxide_core::prelude::{Requester, UserId};
 use crate::error::{PermissionsDenied, handle_status, IdOrUsernameNotValid, handle_target_ban};
 use crate::prelude::Bot;
 use crate::utils::{MessageExt, Timer};
@@ -53,12 +48,12 @@ pub async fn banning(bot: Bot, msg: Message) -> ResponseResult<()> {
 
     // Ban for reply to a Join Event (/ban <user> Joined the group)
     let Some(user) = replied.from() else {
-        let Some(user) = msg.extract_first_new_member(&msg) else {
+        let Some(user) = msg.extract_new_member_info(&msg) else {
             return Ok(())
         };
 
         bot.ban_chat_member(msg.chat.id, user.id).await?;
-        bot.send_message(msg.chat.id, "✅ Usuario desbaneado")
+        bot.send_message(msg.chat.id, "✅ Usuario baneado")
             .reply_to_message_id(msg.id).await?
             .delete_message_timer(bot, msg.chat.id, msg.id, 10);
 

--- a/src/commands/admin/mute.rs
+++ b/src/commands/admin/mute.rs
@@ -1,12 +1,7 @@
-use teloxide_core::{
-    payloads::SendMessageSetters,
-    prelude::{
-        Requester,
-        UserId
-    },
-    requests::ResponseResult,
-    types::Message
-};
+use teloxide_core::payloads::SendMessageSetters;
+use teloxide_core::prelude::{Requester, UserId};
+use teloxide_core::requests::ResponseResult;
+use teloxide_core::types::Message;
 use teloxide_core::types::ChatPermissions;
 use crate::error::{PermissionsDenied, handle_status, IdOrUsernameNotValid, handle_target_mute};
 use crate::prelude::Bot;
@@ -48,7 +43,7 @@ pub async fn muting(bot: Bot, msg: Message) -> ResponseResult<()> {
 
     // Mute for reply to a Join Event (/mute <user> Joined the group)
     let Some(user) = replied.from() else {
-        let Some(user) = msg.extract_first_new_member(&msg) else {
+        let Some(user) = msg.extract_new_member_info(&msg) else {
             return Ok(())
         };
         bot.restrict_chat_member(msg.chat.id, user.id,ChatPermissions::empty()).await?;

--- a/src/commands/admin/unban.rs
+++ b/src/commands/admin/unban.rs
@@ -43,7 +43,7 @@ pub async fn unbanning(bot: Bot, msg: Message) -> ResponseResult<()> {
 
     // Unban for reply to a Join Event (/unban <user> Joined the group)
     let Some(user) = replied.from() else {
-        let Some(user) = msg.extract_first_new_member(&msg) else {
+        let Some(user) = msg.extract_new_member_info(&msg) else {
             return Ok(())
         };
 

--- a/src/commands/admin/unmute.rs
+++ b/src/commands/admin/unmute.rs
@@ -1,15 +1,7 @@
-use teloxide_core::{
-    payloads::SendMessageSetters,
-    requests::ResponseResult,
-    prelude::{
-        Requester,
-        UserId
-    },
-    types::{
-        Message,
-        ChatPermissions
-    }
-};
+use teloxide_core::prelude::{Requester, UserId};
+use teloxide_core::types::{Message, ChatPermissions};
+use teloxide_core::requests::ResponseResult;
+use teloxide_core::payloads::SendMessageSetters;
 use crate::prelude::Bot;
 use crate::error::{PermissionsDenied, handle_status, IdOrUsernameNotValid, handle_target_mute, NotMuted};
 use crate::utils::{MessageExt, Timer};
@@ -49,7 +41,7 @@ pub async fn unmuting(bot: Bot, msg: Message) -> ResponseResult<()> {
 
     // Unmute for reply to a Join Event (/unmute <user> Joined the group)
     let Some(user) = replied.from() else {
-        let Some(user) = msg.extract_first_new_member(&msg) else {
+        let Some(user) = msg.extract_new_member_info(&msg) else {
             return Ok(())
         };
         bot.restrict_chat_member(msg.chat.id, user.id,ChatPermissions::all()).await?;

--- a/src/commands/common/mod.rs
+++ b/src/commands/common/mod.rs
@@ -1,16 +1,8 @@
-use crate::{
-    prelude::Bot,
-    utils::Timer,
-};
-use teloxide_core::{
-    payloads::SendMessageSetters,
-    prelude::Requester,
-    requests::ResponseResult,
-    types::{
-        Message,
-        ParseMode::MarkdownV2,
-    },
-};
+use crate::{prelude::Bot, utils::Timer};
+use teloxide_core::{payloads::SendMessageSetters, prelude::Requester, requests::ResponseResult};
+use teloxide_core::types::{Message, ParseMode::MarkdownV2};
+use teloxide_core::prelude::UserId;
+use crate::utils::MessageExt;
 
 pub async fn handle_docs(
     bot: Bot,
@@ -56,6 +48,42 @@ pub async fn help(bot: Bot, msg: Message) -> ResponseResult<()> {
 pub async fn start(bot: Bot, msg: Message) -> ResponseResult<()> {
     bot.send_message(msg.chat.id, "Todo").await?
         .delete_message_timer(bot, msg.chat.id, msg.id, 5);
+
+    Ok(())
+}
+
+pub async fn info(bot: Bot, msg: Message) -> ResponseResult<()> {
+    // Info for @username/user_id (/info @username) (/info 12345678)
+    let Some(replied) = msg.reply_to_message() else {
+        let parsed_id = msg.parse_id().await;
+        let info = bot.get_chat_member(msg.chat.id, UserId(parsed_id)).await?;
+        let first_name = info.user.first_name;
+        let last_name = info.user.last_name.unwrap_or_else(|| "Ninguno".to_owned());
+        let username = info.user.username.unwrap_or_default();
+        let user_id = info.user.id;
+        let user_info = format!("Nombre: {first_name} \nApellido: {last_name} \nUsername: @{username} \nuser_id: <code>{user_id}</code>");
+
+        bot.send_message(msg.chat.id, user_info)
+            .reply_to_message_id(msg.id).await?
+            .delete_message_timer(bot, msg.chat.id, msg.id, 60);
+
+        return Ok(())
+    };
+
+    // Info for reply to a message (/info <replying message>)
+    // panic if replied a remove join event (e.g "User removed Target)
+    let from = replied.from().unwrap_or_else(|| replied.new_chat_members().unwrap_or_default().first().unwrap());
+    let info = bot.get_chat_member(msg.chat.id, from.id).await?;
+
+    let first_name = info.user.first_name;
+    let last_name = info.user.last_name.unwrap_or_else(|| "Ninguno".to_owned());
+    let username = info.user.username.unwrap_or_default();
+    let user_id = info.user.id;
+    let user_info = format!("Nombre: {first_name} \nApellido: {last_name} \nUsername: @{username} \nuser_id: <code>{user_id}</code>");
+
+    bot.send_message(msg.chat.id, user_info)
+        .reply_to_message_id(msg.id).await?
+        .delete_message_timer(bot, msg.chat.id, msg.id, 60);
 
     Ok(())
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -14,6 +14,7 @@ pub enum AdminCommands {
 pub enum BotCommonCommands {
     Start,
     Help,
+    Info,
 }
 
 #[derive(BotCommands, Clone, Debug)]

--- a/src/handlers/command.rs
+++ b/src/handlers/command.rs
@@ -22,13 +22,9 @@ use crate::{
     prelude::Bot,
 };
 use teloxide::utils::command::BotCommands;
-use teloxide_core::{
-    requests::ResponseResult,
-    types::{
-        Me,
-        Message,
-    },
-};
+use teloxide_core:: types::{Me, Message};
+use teloxide_core::requests::ResponseResult;
+use crate::commands::common::info;
 use crate::utils::db::get_user_data;
 
 pub async fn common_command_handler(
@@ -40,6 +36,7 @@ pub async fn common_command_handler(
     match BotCommands::parse(text, me.username()) {
         Ok(BotCommonCommands::Start) => start(bot, msg).await?,
         Ok(BotCommonCommands::Help) => help(bot, msg).await?,
+        Ok(BotCommonCommands::Info) => info(bot, msg).await?,
         _ => docs_command_handler(bot, msg, me).await?,
     }
 


### PR DESCRIPTION
Corrigiendo bug crítico en el método parse_id (si se usaba el comando proporcionando un `user_id` el Bot aplicaba un `unwrap_or_default()` ocasionando que el método devolviera un 0