### PR TITLE
📦️ update: Actualizando dependencias para remover el uso de OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-teloxide = { version = "0.12.2", features = ["macros"] }
-teloxide-core = "0.9.1"
+teloxide = { version = "0.12.2", features = ["macros", "rustls", "ctrlc_handler"], default-features = false }
+teloxide-core = { version = "0.9.1", features = ["rustls"], default-features = false }
 log = "0.4.17"
 pretty_env_logger = "0.5.0"
 tokio = { version =  "1.21.2", features = ["full"] }
 dotenv= "0.15.0"
-reqwest = "0.11.13"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.93"
-nekosbest = "0.20.1"
-surrealdb = { version = "1.0.0", features = ["kv-mem"] }
+nekosbest = { version = "0.20.1", features = ["rustls-tls"], default-features = false }
+surrealdb = { version = "1.0.0", features = ["kv-mem", "rustls"], default-features = false }
 once_cell = "1.18.0"

--- a/Shuttle.toml
+++ b/Shuttle.toml
@@ -1,1 +1,0 @@
-name = "kanizawa-sensei-bot"


### PR DESCRIPTION
Se han actualizando dependencias para remover el uso de OpenSSL a cambio de Rustls